### PR TITLE
fix compiler warning

### DIFF
--- a/EBYTE.cpp
+++ b/EBYTE.cpp
@@ -692,10 +692,8 @@ uint8_t EBYTE::GetFeatures() {
 }
 void EBYTE::ClearBuffer(){
 
-	byte b;
-
 	while(_s->available()) {
-		b = _s->read();
+		_s->read();
 	}
 
 }


### PR DESCRIPTION
fix for the ```warning: variable 'b' set but not used [-Wunused-but-set-variable]``` warning